### PR TITLE
Remove invalid houjinkaku type "一般財産法人"

### DIFF
--- a/internal/toukibo/houjin_kaku.go
+++ b/internal/toukibo/houjin_kaku.go
@@ -30,7 +30,6 @@ const (
 	HoujinKakuShakaifukusi    HoujinkakuType = "社会福祉法人"
 	HoujinKakuIppanShadan     HoujinkakuType = "一般社団法人"
 	HoujinKakuKouekiShadan    HoujinkakuType = "公益社団法人"
-	HoujinKakuIppanZaisan     HoujinkakuType = "一般財産法人"
 	HoujinKakuIppanZaidan     HoujinkakuType = "一般財団法人"
 	HoujinKakuNPO             HoujinkakuType = "NPO法人"
 	HoujinKakuTokuteiHieiri   HoujinkakuType = "特定非営利活動法人"
@@ -269,8 +268,6 @@ func FindHoujinKaku(name, s string) HoujinkakuType {
 		return HoujinKakuIppanShadan
 	} else if strings.Contains(name, "公益社団法人") {
 		return HoujinKakuKouekiShadan
-	} else if strings.Contains(name, "一般財産法人") {
-		return HoujinKakuIppanZaisan
 	} else if strings.Contains(name, "一般財団法人") {
 		return HoujinKakuIppanZaidan
 	} else if strings.Contains(name, "NPO法人") || strings.Contains(name, "ＮＰＯ法人") {

--- a/internal/toukibo/houjin_kaku_test.go
+++ b/internal/toukibo/houjin_kaku_test.go
@@ -282,12 +282,6 @@ func TestFindHoujinKaku(t *testing.T) {
 			expected: toukibo.HoujinKakuKouekiShadan,
 		},
 		{
-			name:     "一般財産法人のケース",
-			input:    "一般財産法人テスト",
-			content:  "",
-			expected: toukibo.HoujinKakuIppanZaisan,
-		},
-		{
 			name:     "一般財団法人のケース",
 			input:    "一般財団法人テスト",
 			content:  "",


### PR DESCRIPTION
## Summary
- Remove `HoujinKakuIppanZaisan` (一般財産法人) which is an incorrect legal entity type
- The correct type is "一般財団法人" (general incorporated foundation), not "一般財産法人"

## Changes
- Remove constant definition `HoujinKakuIppanZaisan`
- Remove check logic from `FindHoujinKaku` function
- Remove test case for 一般財産法人

## Verification
- Verified that no testdata YAML files (1524 files) use this incorrect type
- All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)