### PR TITLE
Fix parsing of 職務執行者 with half-width space separator

### DIFF
--- a/internal/toukibo/parse_body.go
+++ b/internal/toukibo/parse_body.go
@@ -156,7 +156,7 @@ func getMultipleExecutiveNamesAndPositions(s string) (result []struct{ Name, Pos
 
 			onNameAndPos = false
 		}
-		if match := regexp.MustCompile(fmt.Sprintf("(%s)　+([%s]+)", positionsPattern, ZenkakuStringPattern)).FindStringSubmatch(b); len(match) == 3 {
+		if match := regexp.MustCompile(fmt.Sprintf("(%s)[ 　]+([%s]+)", positionsPattern, ZenkakuStringPattern)).FindStringSubmatch(b); len(match) == 3 {
 			// NOTE: 名前や役職が複数行にまたがる可能性があり、Name と Position は次行以降の内容も踏まえて確定させる必要がある
 			onNameAndPos = true
 			result = append(result, struct{ Name, Position string }{Name: trimAllSpace(match[2]), Position: trimAllSpace(match[1])})


### PR DESCRIPTION
## Summary
- Fixed parsing issue for 職務執行者 (job executor) entries that use half-width spaces between position and name
- Updated regex pattern in `parse_body.go` to accept both half-width (` `) and full-width (`　`) spaces

## Problem
The parser was only matching position-name pairs separated by full-width spaces (`　+`). However, some registration documents (samples 770, 796, 797, 866) use half-width spaces, causing 職務執行者 entries to be missed.

## Solution
Changed the regex pattern from `(%s)　+([%s]+)` to `(%s)[ 　]+([%s]+)` to accept both space types.

## Test plan
- [x] Verified samples 770, 796, 797, 866 now pass their tests
- [x] Ran full test suite (1522 samples) - all tests pass
- [x] No regressions in existing functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)