### PR TITLE
Fix open command to use xdg-open on Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,11 @@ open/sample:
 ifndef TARGET
 	$(error TARGET is not set. Usage: make open/sample TARGET=sample1)
 endif
+ifeq ($(shell uname -s),Linux)
+	xdg-open $(DATA_DIR)/pdf/$(TARGET).pdf
+else
 	open $(DATA_DIR)/pdf/$(TARGET).pdf
+endif
 
 clean: clean/bin clean/data
 


### PR DESCRIPTION
## Summary
- Update `open/sample` Makefile target to detect the operating system
- Use `xdg-open` on Linux systems
- Continue using `open` on macOS and other platforms

## Test plan
- [ ] Run `make open/sample TARGET=sample1` on Linux to verify xdg-open is used
- [ ] Run `make open/sample TARGET=sample1` on macOS to verify open is still used

🤖 Generated with [Claude Code](https://claude.com/claude-code)