### PR TITLE
Fix parsing of 渡邉 (Watanabe) kanji variant

### DIFF
--- a/internal/toukibo/zenkaku.go
+++ b/internal/toukibo/zenkaku.go
@@ -116,6 +116,8 @@ func normalizeKanji(input string) string {
 			sb.WriteRune('楢')
 		case 57447:
 			sb.WriteRune('橋')
+		case 57687:
+			sb.WriteRune('邉')
 		default:
 			sb.WriteRune(r)
 		}


### PR DESCRIPTION
## Summary
- PDFのToUnicodeマップで「邉」が私用領域コード(U+E157)にマッピングされていたため、「渡邉」が「渡」だけにパースされていた問題を修正
- `normalizeKanji`関数にコード57687→「邉」のマッピングを追加

## Test plan
- [x] `make test` passed
- [x] sample1523.pdfで「渡邉紘平」が正しくパースされることを確認