### PR TITLE
Fix parsing of Cyrillic homoglyphs in PDF text

### DIFF
--- a/internal/toukibo/parse_body.go
+++ b/internal/toukibo/parse_body.go
@@ -64,6 +64,7 @@ func getRegisterAt(s string) (string, error) {
 
 func getResignedAt(s string) (string, error) {
 	// 辞任/退任の他に死亡、抹消、廃止、解任、退社、責任変更も含める
+	// 注：資格変更は役職の追加を意味するため、辞任とは異なり含めない
 	date, found := ExtractDateWithSuffix(s, []string{"辞任", "退任", "死亡", "抹消", "廃止", "解任", "退社", "責任変更"})
 	if found {
 		return trimAllSpace(date), nil

--- a/internal/toukibo/zenkaku.go
+++ b/internal/toukibo/zenkaku.go
@@ -118,6 +118,30 @@ func normalizeKanji(input string) string {
 			sb.WriteRune('橋')
 		case 57687:
 			sb.WriteRune('邉')
+		// Cyrillic homoglyphs → Fullwidth Latin
+		// PDF font encoding sometimes maps Latin glyphs to Cyrillic codepoints
+		case 'А': // U+0410 → Ａ
+			sb.WriteRune('Ａ')
+		case 'В': // U+0412 → Ｂ
+			sb.WriteRune('Ｂ')
+		case 'Е': // U+0415 → Ｅ
+			sb.WriteRune('Ｅ')
+		case 'К': // U+041A → Ｋ
+			sb.WriteRune('Ｋ')
+		case 'М': // U+041C → Ｍ
+			sb.WriteRune('Ｍ')
+		case 'Н': // U+041D → Ｎ
+			sb.WriteRune('Ｎ')
+		case 'О': // U+041E → Ｏ
+			sb.WriteRune('Ｏ')
+		case 'Р': // U+0420 → Ｒ
+			sb.WriteRune('Ｒ')
+		case 'С': // U+0421 → Ｓ
+			sb.WriteRune('Ｓ')
+		case 'Т': // U+0422 → Ｔ
+			sb.WriteRune('Ｔ')
+		case 'Х': // U+0425 → Ｘ
+			sb.WriteRune('Ｘ')
 		default:
 			sb.WriteRune(r)
 		}


### PR DESCRIPTION
## Summary
- PDF font encoding sometimes maps Latin glyphs to Cyrillic codepoints (e.g., Cyrillic М U+041C instead of Fullwidth Latin Ｍ U+FF2D)
- This caused names like `ＲＳＭ清和監査法人` (会計監査人) to be truncated to `ＲＳ` because the Cyrillic character fell outside `ZenkakuStringPattern`
- Add Cyrillic-to-Fullwidth-Latin normalization in `normalizeKanji` for 11 visually identical homoglyph pairs (А→Ａ, В→Ｂ, Е→Ｅ, К→Ｋ, М→Ｍ, Н→Ｎ, О→Ｏ, Р→Ｒ, С→Ｓ, Т→Ｔ, Х→Ｘ)

## Test plan
- [x] `make run/sample TARGET=sample1524` で `ＲＳＭ清和監査法人` が正しく出力されることを確認
- [x] `make test` で全テスト通過を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)