### PR TITLE
Add HoujinPurpose parsing and annotate output

### DIFF
--- a/internal/toukibo/houjin_body.go
+++ b/internal/toukibo/houjin_body.go
@@ -10,6 +10,7 @@ type HoujinBody struct {
 	HoujinKaku         HoujinkakuType
 	HoujinName         HoujinValueArray
 	HoujinAddress      HoujinValueArray
+	HoujinPurpose      HoujinValueArray
 	HoujinKoukoku      string
 	HoujinCreatedAt    string
 	HoujinBankruptedAt string
@@ -22,10 +23,11 @@ type HoujinBody struct {
 }
 
 func (h *HoujinBody) String() string {
-	out := fmt.Sprintf("Body\n法人番号 : %s\n法人名  : %s\n法人住所 : %s\n公告   : %s\n成立年月日: %s\n解散年月日: %s\n資本金  : %s\n登記記録 : %s\n",
+	out := fmt.Sprintf("Body\n法人番号 : %s\n法人名  : %s\n法人住所 : %s\n目的   : %s\n公告   : %s\n成立年月日: %s\n解散年月日: %s\n資本金  : %s\n登記記録 : %s\n",
 		h.HoujinNumber,
 		h.HoujinName,
 		h.HoujinAddress,
+		h.HoujinPurpose,
 		h.HoujinKoukoku,
 		h.HoujinCreatedAt,
 		h.HoujinDissolvedAt,

--- a/internal/toukibo/parse.go
+++ b/internal/toukibo/parse.go
@@ -92,6 +92,19 @@ func (h *Houjin) GetHoujinAddress() string {
 	return h.header.CompanyAddress
 }
 
+func (h *Houjin) GetHoujinPurposeHistory() HoujinValueArray {
+	return h.body.HoujinPurpose
+}
+
+func (h *Houjin) GetHoujinPurpose() string {
+	for _, v := range h.body.HoujinPurpose {
+		if v.IsValid {
+			return v.Value
+		}
+	}
+	return ""
+}
+
 func (h *Houjin) GetHoujinCreatedAt() string {
 	return h.body.HoujinCreatedAt
 }

--- a/internal/toukibo/purpose_parser_test.go
+++ b/internal/toukibo/purpose_parser_test.go
@@ -1,0 +1,75 @@
+package toukibo
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseBodyMainParsesHoujinPurposeWithHistory(t *testing.T) {
+	pair := " ┃目　的　　　　　│　１．旧目的　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　┃ " +
+		revert1 +
+		" ┃　　　　　　　　│　１．新目的　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　┃ " +
+		"┃　　　　　　　　│　　　　　　　　　令和　３年　６月２５日変更　　令和　３年　７月１２日登記┃ "
+
+	h, err := ParseBody([]string{pair})
+	if err != nil {
+		t.Fatalf("ParseBody returned error: %v", err)
+	}
+
+	if len(h.HoujinPurpose) != 2 {
+		t.Fatalf("expected 2 purpose history entries, got %d", len(h.HoujinPurpose))
+	}
+
+	if h.HoujinPurpose[0].IsValid {
+		t.Fatalf("expected first purpose entry to be invalid")
+	}
+	if h.HoujinPurpose[0].Value != "１．旧目的" {
+		t.Fatalf("unexpected first purpose value: %q", h.HoujinPurpose[0].Value)
+	}
+
+	if !h.HoujinPurpose[1].IsValid {
+		t.Fatalf("expected latest purpose entry to be valid")
+	}
+	if h.HoujinPurpose[1].Value != "１．新目的" {
+		t.Fatalf("unexpected latest purpose value: %q", h.HoujinPurpose[1].Value)
+	}
+	if h.HoujinPurpose[1].RegisterAt != "令和３年７月１２日" {
+		t.Fatalf("unexpected registerAt: %q", h.HoujinPurpose[1].RegisterAt)
+	}
+}
+
+func TestParseBodyMainParsesHoujinPurposeTou(t *testing.T) {
+	pair := " ┃目的等　　　　　│　事業　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　┃ " +
+		"┃　　　　　　　　│　⑴　テスト事業　　　　　　　　　　　　　　　　　　　　　　　　　　　　　┃ "
+
+	h, err := ParseBody([]string{pair})
+	if err != nil {
+		t.Fatalf("ParseBody returned error: %v", err)
+	}
+
+	if len(h.HoujinPurpose) != 1 {
+		t.Fatalf("expected 1 purpose entry, got %d", len(h.HoujinPurpose))
+	}
+	if !h.HoujinPurpose[0].IsValid {
+		t.Fatalf("expected purpose entry to be valid")
+	}
+	if !strings.Contains(h.HoujinPurpose[0].Value, "事業") || !strings.Contains(h.HoujinPurpose[0].Value, "テスト事業") {
+		t.Fatalf("unexpected purpose value: %q", h.HoujinPurpose[0].Value)
+	}
+}
+
+func TestGetHoujinPurposeReturnsLatestValidValue(t *testing.T) {
+	h := &Houjin{body: &HoujinBody{HoujinPurpose: HoujinValueArray{
+		{Value: "１．旧目的", IsValid: false},
+		{Value: "１．新目的", IsValid: true},
+	}}}
+
+	if got := h.GetHoujinPurpose(); got != "１．新目的" {
+		t.Fatalf("GetHoujinPurpose() = %q, want %q", got, "１．新目的")
+	}
+
+	history := h.GetHoujinPurposeHistory()
+	if len(history) != 2 {
+		t.Fatalf("GetHoujinPurposeHistory length = %d, want 2", len(history))
+	}
+}

--- a/scripts/main.go
+++ b/scripts/main.go
@@ -63,6 +63,7 @@ func mainRun() error {
 	fmt.Println("HoujinKaku: " + h.GetHoujinKaku())
 	fmt.Println("HoujinName: " + h.GetHoujinName())
 	fmt.Println("HoujinAddress: " + h.GetHoujinAddress())
+	fmt.Println("HoujinPurpose: " + h.GetHoujinPurpose())
 	fmt.Print("HoujinExecutiveValues: \n" + execs.String())
 	fmt.Println("HoujinExecutiveNames: [" + strings.Join(execNames, ",") + "]")
 	fmt.Println("HoujinRepresentativeNames: [" + strings.Join(repName, ",") + "]")


### PR DESCRIPTION
## Summary
- add `HoujinPurpose` to parsed body and expose it via `GetHoujinPurpose()` / `GetHoujinPurposeHistory()`
- parse `┃目　的` and `┃目的等` in `ParseBodyMain` instead of skipping those fields
- include `HoujinPurpose` in `scripts/main.go` output so `make annotate/all` writes it into `testdata/yaml/*.yaml`
- add parser tests for purpose parsing (history, registerAt, and latest-value getter)

## Validation
- `go test ./internal/toukibo -count=1 -v`
- `go test ./... -run '^$'`
- `make annotate/all`
- `make put/sample`
