### PR TITLE
Update Go version from 1.25 to 1.26

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.25'
+        go-version: '1.26'
         cache: true
         cache-dependency-path: src
     - name: Build
@@ -27,7 +27,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.25'
+        go-version: '1.26'
         cache: true
         cache-dependency-path: src
     - name: Get sample

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/tychy/toukibo-parser
 
-go 1.25
+go 1.26
 
 require gopkg.in/yaml.v3 v3.0.1


### PR DESCRIPTION
## Summary
- Go のバージョンを 1.25 から 1.26 に更新
- `go.mod` と CI ワークフロー (`.github/workflows/go.yml`) の両方を更新

## Test plan
- [x] CI のビルドジョブが Go 1.26 で成功することを確認
- [x] CI のテストジョブが Go 1.26 で成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)