### PR TITLE
Fix: PUA character mapping for 四

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 BUCKET_NAME=toukibo-parser-samples
 URL=https://pub-a26a7972d1ea437b983bf6696a7d847e.r2.dev
 DATA_DIR=testdata
-export NUM_SAMPLE=1522
+export NUM_SAMPLE=1525
 
 build:
 	mkdir -p bin

--- a/internal/toukibo/zenkaku.go
+++ b/internal/toukibo/zenkaku.go
@@ -118,6 +118,8 @@ func normalizeKanji(input string) string {
 			sb.WriteRune('橋')
 		case 57687:
 			sb.WriteRune('邉')
+		case 61066:
+			sb.WriteRune('四')
 		// Cyrillic homoglyphs → Fullwidth Latin
 		// PDF font encoding sometimes maps Latin glyphs to Cyrillic codepoints
 		case 'А': // U+0410 → Ａ


### PR DESCRIPTION
## Summary
- 一般財団法人日本規格協会の登記簿PDFで、「四」がPDF内でU+EE8A（Private Use Area）としてエンコードされており、名前が空になっていた問題を修正
- `normalizeKanji` にU+EE8A → '四' のマッピングを追加
- テストサンプル sample1525 として当該PDFを追加（NUM_SAMPLE: 1522 → 1525）

## Test plan
- [x] `make build && ./bin/toukibo-parser` で「四」が正しくパースされることを確認
- [x] `make test` で全テストパス
- [ ] `make put/sample` でR2にテストデータをアップロード（要 CLOUDFLARE_API_TOKEN）